### PR TITLE
Fixed wrong translation for default options and updated documentation to make it more noobs-friendly

### DIFF
--- a/doc/9verb_intro.rst
+++ b/doc/9verb_intro.rst
@@ -180,20 +180,29 @@ No additional walking will occur. This is useful for exits not being at the scre
 Language & Translation
 ======================
 
-Currently the GUI supports German, French, Spanish, Portuguese and Dutch. If you like to help translating this template, please drop me a PM at the AGS Forums.
+Currently the GUI supports German, French, Spanish, Italian, Portuguese and Dutch. If you like to help translating this template, please drop me a PM at the AGS Forums.
 
-If you like to create your game in a different language than english, you need to set it up. In the TemplateSettings.asc module you'll find the line:
+If you like to create your game in a different language than English, you need to setup a different default language. In the TemplateSettings.asc module you'll find the line:
 
 ::
 
 	Verbs.VerbGuiOptions[eVerbGuiTemplateLanguage] = eLangEN;
 
-At the time of writing, valid values are: eLangEN, eLangES, eLangFR, eLangDE and eLandNL. Setting this variable to one of these values will translate all your GUIs,
-including all provided dialogs. The unhandled events will stay unchanged however. Those are still needed to be changed directly.
-To switch the language in a .trs translation file, tell your translators to look out for the line.
+At the time of writing, valid values are: eLangEN, eLangDE, eLangES, eLangFR, eLangIT, eLangPT, eLangNL. Setting this variable to one of these values will translate all your GUIs,
+including all provided dialogs, unhandled events and verb actions.
+
+If you are providing a multilanguage game, which default language is English instead, you will probably create one or more AGS translation files. Sadly AGS won't automatically change GUI graphics by the language preference set by running the game setup, but we got you covered with this: after generating a new language, tell your translators to look out for the line.
 
 ::
 
 	GUI_LANGUAGE
 
-Now simply translate that line to *EN, DE, ES, FR, IT, PT or NL* to set the GUI to the corresponding language.
+Now simply put a translation for that line chosing between *EN, DE, ES, FR, IT, PT or NL*.
+For example:
+
+::
+
+	GUI_LANGUAGE
+	DE
+
+Now the GUI will be set to the corresponding language when the user selects a different language by running game setup.

--- a/doc/9verb_intro.rst
+++ b/doc/9verb_intro.rst
@@ -186,7 +186,7 @@ If you like to create your game in a different language than english, you need t
 
 ::
 
-	int lang = eLangEN;
+	Verbs.VerbGuiOptions[eVerbGuiTemplateLanguage] = eLangEN;
 
 At the time of writing, valid values are: eLangEN, eLangES, eLangFR, eLangDE and eLandNL. Setting this variable to one of these values will translate all your GUIs,
 including all provided dialogs. The unhandled events will stay unchanged however. Those are still needed to be changed directly.
@@ -196,4 +196,4 @@ To switch the language in a .trs translation file, tell your translators to look
 
 	GUI_LANGUAGE
 
-Now simply translate that line with *DE, EN, ES, FR, PT or NL* to set the GUI to the corresponding language.
+Now simply translate that line to *EN, DE, ES, FR, IT, PT or NL* to set the GUI to the corresponding language.

--- a/verbgui.asc
+++ b/verbgui.asc
@@ -1396,7 +1396,7 @@ static void Verbs::AdjustGUIText()
     lblOptionsStyle.Text   = "Disposizione";
     lblOptionsGuiClassic.Text = "classica";
     lblOptionsGuiModern.Text  = "moderna";     
-    btnOptionsDefault.Text = "Risedersi";
+    btnOptionsDefault.Text = "Predefinite";
     btnOptionsSave.Text    = "Salva";
     btnOptionsLoad.Text    = "Carica";
     btnOptionsQuit.Text    = "Esci";


### PR DESCRIPTION
**About the fixed translation:** Not sure why this word was used for "Default" but "Risedersi" is a very strange word, meaning "Sitting down again". In OS and apps all alike "Predefinite" is the most common word for "Default" and it fits the button (checked).

**About the docs:** I followed the hits you gave me on the forum to make things clearer to newbies like me. Hope it won't sound too childish and (mostly) that I didn't wrote incorrect information.