### PR TITLE
Switch to newer style extender declarations

### DIFF
--- a/CustomDialogGui.asc
+++ b/CustomDialogGui.asc
@@ -92,7 +92,7 @@ String CDG_active_options_text[];
 bool in_speech;
 
 /***********************************************************************
- * seti_DialogGuiOptions(this CustomDialogGui*, eDialogGuiOptions index,  int value)
+ * seti_DialogGuiOptions(static CustomDialogGui, eDialogGuiOptions index,  int value)
  * sets the options for the dialog GUI
  ***********************************************************************/
 bool seti_DialogGuiOptions(static CustomDialogGui, eDialogGuiOptions index,  int value) 
@@ -151,7 +151,7 @@ bool seti_DialogGuiOptions(static CustomDialogGui, eDialogGuiOptions index,  int
 }
 
 /***********************************************************************
- * geti_DialogGuiOptions(this CustomDialogGui*, eDialogGuiOptions index,  int value)
+ * geti_DialogGuiOptions(static CustomDialogGui, eDialogGuiOptions index,  int value)
  * gets the options for the dialog GUI
  ***********************************************************************/
 int geti_DialogGuiOptions(static CustomDialogGui, eDialogGuiOptions index)

--- a/DoubleClick.asc
+++ b/DoubleClick.asc
@@ -27,12 +27,12 @@ MBtnRecord  MBtnRec[TOP_REF_MOUSE_BTN];
 // DoubleClick::Timeout property
 //
 //===========================================================================
-int get_Timeout(this DoubleClick*)
+int get_Timeout(static DoubleClick)
 {
   return DblClk.Timeout;
 }
 
-void set_Timeout(this DoubleClick*, int value)
+void set_Timeout(static DoubleClick, int value)
 {
   if (value < 0) value = 0;
   DblClk.Timeout = value;
@@ -43,7 +43,7 @@ void set_Timeout(this DoubleClick*, int value)
 // DoubleClick::Event[] property
 //
 //===========================================================================
-bool geti_Event(this DoubleClick*, MouseButton mb)
+bool geti_Event(static DoubleClick, MouseButton mb)
 {
   if (mb < 0 || mb >= TOP_REF_MOUSE_BTN)
     return false;

--- a/verbgui.asc
+++ b/verbgui.asc
@@ -151,7 +151,7 @@ VerbsData verbsData;
 // ============================= Helper functions ===========================================
 
 /***********************************************************************
- * seti_VerbGuiOptions(this Verbs*, eVerbGuiOptions index,  int value) 
+ * seti_VerbGuiOptions(static Verbs, eVerbGuiOptions index,  int value)
  * sets the template's options for the given index
  * 
  ***********************************************************************/
@@ -220,7 +220,7 @@ bool seti_VerbGuiOptions(static Verbs, eVerbGuiOptions index,  int value)
 }
 
 /***********************************************************************
- * geti_VerbGuiOptions(this Verbs*, eVerbGuiOptions index)
+ * geti_VerbGuiOptions(static Verbs, eVerbGuiOptions index)
  * Returns the template's options for the given index
  * 
  ***********************************************************************/
@@ -250,7 +250,7 @@ int geti_VerbGuiOptions(static Verbs, eVerbGuiOptions index)
 }
 
 /***********************************************************************
- * seti_VerbGuiUnhandled(this Verbs*, eVerbGuiOptions index,  int value) 
+ * seti_VerbGuiUnhandled(static Verbs, eVerbGuiOptions index,  int value)
  * sets the messages for the unhandled events
  * 
  ***********************************************************************/
@@ -260,7 +260,7 @@ bool seti_VerbGuiUnhandled(static Verbs, eVerbGuiUnhandled index, String value)
 }
 
 /***********************************************************************
- * geti_VerbGuiUnhandled(this Verbs*, eVerbGuiOptions index,  int value) 
+ * geti_VerbGuiUnhandled(static Verbs, eVerbGuiOptions index,  int value)
  * gets the messages for the unhandled events
  * 
  ***********************************************************************/
@@ -408,7 +408,7 @@ static void Verbs::HandleInvArrows()
 
 // ============================= door init functions ===========================================
 /***********************************************************************
- * seti_VerbGuiUnhandled(this Verbs*, eVerbGuiOptions index,  int value) 
+ * seti_VerbGuiUnhandled(static Verbs, eVerbGuiOptions index,  int value)
  * sets the messages for the unhandled events
  * 
  ***********************************************************************/
@@ -418,7 +418,7 @@ bool seti_DoorStrings(static Doors, eDoorStrings index, String value)
 }
 
 /***********************************************************************
- * geti_VerbGuiUnhandled(this Verbs*, eVerbGuiOptions index,  int value) 
+ * geti_VerbGuiUnhandled(static Verbs, eVerbGuiOptions index,  int value)
  * gets the messages for the unhandled events
  * 
  ***********************************************************************/


### PR DESCRIPTION
The older style incorrectly mixes pointers with static methods and won't be supported by the new compiler.
This is discussed at https://github.com/adventuregamestudio/ags-template-source/issues/26