### PR TITLE
Fixed ES translation for save slot

### DIFF
--- a/verbgui.asc
+++ b/verbgui.asc
@@ -1389,7 +1389,7 @@ static void Verbs::AdjustGUIText()
     lblPauseMessage.Text   = "Pulsa Espacio para continuar";
     lblLoad.Text        = "Por favor, elige el juego a cargar";
     btnLoadCancel.Text  = "Cancelar";
-    lblSave.Text        = "Por favor, introduce un nombre";
+    lblSave.Text        = "Por favor, elije un slot a salvar";
     btnSaveCancel.Text  = "Cancelar";
     lblQuitHeadline.Text = "¿Salir del juego?";
     lblQuitMessage.Text  = "¿Seguro que quieres salir?";


### PR DESCRIPTION
Just checking on the `ES` translation and now the `Save/Load` game is slot based, you cannot pick a name 
`lblSave.Text = "Por favor, introduce un nombre";` 
Instead of asking for a name, it would be more accurate to select a `save slot` 😃 