### PR TITLE
Fix auto-inventory scrolling, don't rely on actual items visibility

### DIFF
--- a/verbgui.asc
+++ b/verbgui.asc
@@ -389,7 +389,15 @@ static void Verbs::HandleInvArrows()
     btnInvUp.NormalGraphic    = verbsData.invUparrowONsprite;
     btnInvUp.MouseOverGraphic = verbsData.invUparrowHIsprite;
     
-    if (InventoryItem.GetAtScreenXY(verbsData.guiMain.X + invMain.X + 1, verbsData.guiMain.Y + invMain.Y + 1) == null) invMain.TopItem -= invMain.ItemsPerRow;
+    // test if no items are visible, if not then scroll up until some are
+    if (invMain.TopItem >= invMain.ItemCount) {
+      if (invMain.ItemCount == 0) {
+        invMain.TopItem = 0;
+      }
+      else {
+        invMain.TopItem = ((invMain.ItemCount - 1) / invMain.ItemsPerRow) * invMain.ItemsPerRow;
+      }
+    }
   }
   else { 
     btnInvUp.NormalGraphic    = verbsData.invUparrowOFFsprite;


### PR DESCRIPTION
I found there's a automatic inventory scroll done in case last item got removed from the visible row.

Unfortunately, it's done in a very unreliable way, testing if there's any item at the screen position.
This breaks if action bar gets hidden (e.g. during cutscenes) or if there's any GUI happen to overlay it.

The proposed solution uses strictly InvWindow's properties, compares TopItem with ItemCount, and selects last item row which has any items in it.