### PR TITLE
Add include/exclude pattern file

### DIFF
--- a/template.files
+++ b/template.files
@@ -1,0 +1,33 @@
+# Tumbleweed template include/exclude list
+
+Game.agf
+*.asc
+*.ash
+*.crm
+*.ttf
+*.txt
+*.wfn
+# Have to include the spriteset file, because the AGS Editor reports
+# a missing spriteset as a error (even if source files are present)
+acsprset.spr
+sprindex.dat
+# Sprite assets folder
+assets/
+# May not be used in a particular template, but still mention it
+# in case another template is created based on this
+Speech/
+# Template meta files
+template.ico
+template.txt
+template.files
+tumbleweedverbs.pdf
+
+# Ignore generated folders, user settings and backups
+!_Debug/
+!Compiled/
+!*.bak
+!*.user
+!*.lock
+
+# Ignore audio cache folder, because sounds may be restored from sources
+!AudioCache


### PR DESCRIPTION
Resolves #36

The latest 3.6.2 patch (and following future versions) will have an ability to select files for template packaging using a file with include/exclude patterns, similar to .gitignore.

This allows to also package custom files and folders (such as "assets" folder in this template).

EDIT: hm, I noticed that #36 has a suggestion to rename "assets" into Sprites. I noticed that that folder includes other things than sprites too, so did not do that.